### PR TITLE
fixed dummy manifest path not being correctly parsed on windows

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -174,7 +174,11 @@ fn run_post_build_script() -> Option<process::ExitStatus> {
     let build_script_manifest_path = build_script_manifest_dir.join("Cargo.toml");
     let build_script_manifest_content = format!(
         include_str!("post_build_script_manifest.toml"),
-        file_name = post_build_script_path.display(),
+        file_name = if cfg!(windows) {
+            str::replace(build_script_manifest_path.to_str().unwrap(), "\\", "\\\\")
+        } else {
+            build_script_manifest_path.to_str().unwrap().to_string()
+        },
         dependencies = dependencies_string,
     );
     fs::write(&build_script_manifest_path, build_script_manifest_content)


### PR DESCRIPTION
Hello, while trying to use the crate on Windows, the dummy manifest path was being passed incorrectly to the Toml parser, causing an error to occur. As paths in Windows use `\` instead of `/`, it interpreted it as an escaped character. Due to this, I added an OS verification which adds an extra `\` in case the OS is Windows.