### PR TITLE
Revert "fixed dummy manifest path not being correctly parsed on windows"

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -174,11 +174,7 @@ fn run_post_build_script() -> Option<process::ExitStatus> {
     let build_script_manifest_path = build_script_manifest_dir.join("Cargo.toml");
     let build_script_manifest_content = format!(
         include_str!("post_build_script_manifest.toml"),
-        file_name = if cfg!(windows) {
-            str::replace(build_script_manifest_path.to_str().unwrap(), "\\", "\\\\")
-        } else {
-            build_script_manifest_path.to_str().unwrap().to_string()
-        },
+        file_name = post_build_script_path.display(),
         dependencies = dependencies_string,
     );
     fs::write(&build_script_manifest_path, build_script_manifest_content)


### PR DESCRIPTION
Reverts phil-opp/cargo-post#10

It seems like it doesn't fully fix the build errors on Windows and also introduces failures on Linux.