### PR TITLE
use toml to escape post build script path

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -192,7 +192,7 @@ fn run_post_build_script() -> Option<process::ExitStatus> {
     let build_script_manifest_content = format!(
         include_str!("post_build_script_manifest.toml"),
         file_name = toml::to_string(&post_build_script_path.to_str())
-            .expect("Failed to write post build script manifest"),
+            .expect("Failed to serialize post build script path as TOML string"),
         dependencies = dependencies_string,
     );
     fs::write(&build_script_manifest_path, build_script_manifest_content)

--- a/src/main.rs
+++ b/src/main.rs
@@ -191,7 +191,8 @@ fn run_post_build_script() -> Option<process::ExitStatus> {
     let build_script_manifest_path = build_script_manifest_dir.join("Cargo.toml");
     let build_script_manifest_content = format!(
         include_str!("post_build_script_manifest.toml"),
-        file_name = post_build_script_path.display(),
+        file_name = toml::to_string(&post_build_script_path.to_str())
+            .expect("Failed to write post build script manifest"),
         dependencies = dependencies_string,
     );
     fs::write(&build_script_manifest_path, build_script_manifest_content)

--- a/src/post_build_script_manifest.toml
+++ b/src/post_build_script_manifest.toml
@@ -5,7 +5,7 @@ edition = "2018"
 
 [[bin]]
 name = "post-build-script"
-path = "{file_name}"
+path = {file_name}
 
 [workspace]
 

--- a/tests/dependency/post_build.rs
+++ b/tests/dependency/post_build.rs
@@ -12,6 +12,6 @@ fn main() {
     assert_eq!(env::var("CRATE_TARGET").unwrap(), "");
     assert_eq!(env::var("CRATE_TARGET_TRIPLE").unwrap(), "");
     assert_eq!(PathBuf::from(env::var("CRATE_TARGET_DIR").unwrap()), current_parent.join("target"));
-    assert_eq!(PathBuf::from(env::var("CRATE_OUT_DIR").unwrap()), current_parent.join("target/debug"));
+    assert_eq!(PathBuf::from(env::var("CRATE_OUT_DIR").unwrap()), current_parent.join("target").join("debug"));
     println!("ok");
 }

--- a/tests/dependency/post_build.rs
+++ b/tests/dependency/post_build.rs
@@ -3,13 +3,15 @@ use std::{path::{Path, PathBuf}, env};
 use example as _;
 
 fn main() {
+    let current_dir = env::current_dir().unwrap();
+    let current_parent = current_dir.parent().unwrap();
     assert_eq!(env::var("CRATE_BUILD_COMMAND").unwrap(), "cargo build --package dependency");
-    assert_eq!(PathBuf::from(env::var("CRATE_MANIFEST_DIR").unwrap()), Path::new(".").canonicalize().unwrap());
-    assert_eq!(PathBuf::from(env::var("CRATE_MANIFEST_PATH").unwrap()), Path::new("Cargo.toml").canonicalize().unwrap());
+    assert_eq!(PathBuf::from(env::var("CRATE_MANIFEST_DIR").unwrap()), current_dir);
+    assert_eq!(PathBuf::from(env::var("CRATE_MANIFEST_PATH").unwrap()), current_dir.join("Cargo.toml"));
     assert_eq!(env::var("CRATE_PROFILE").unwrap(), "debug");
     assert_eq!(env::var("CRATE_TARGET").unwrap(), "");
     assert_eq!(env::var("CRATE_TARGET_TRIPLE").unwrap(), "");
-    assert_eq!(PathBuf::from(env::var("CRATE_TARGET_DIR").unwrap()), Path::new("../target").canonicalize().unwrap());
-    assert_eq!(PathBuf::from(env::var("CRATE_OUT_DIR").unwrap()), Path::new("../target").join("debug").canonicalize().unwrap());
+    assert_eq!(PathBuf::from(env::var("CRATE_TARGET_DIR").unwrap()), current_parent.join("target"));
+    assert_eq!(PathBuf::from(env::var("CRATE_OUT_DIR").unwrap()), current_parent.join("target/debug"));
     println!("ok");
 }

--- a/tests/simple/post_build.rs
+++ b/tests/simple/post_build.rs
@@ -1,13 +1,15 @@
-use std::{path::{Path, PathBuf}, env};
+use std::{path::PathBuf, env};
 
 fn main() {
+    let current_dir = env::current_dir().unwrap();
+    let current_parent = current_dir.parent().unwrap();
     assert_eq!(env::var("CRATE_BUILD_COMMAND").unwrap(), "cargo build --package simple");
-    assert_eq!(PathBuf::from(env::var("CRATE_MANIFEST_DIR").unwrap()), Path::new(".").canonicalize().unwrap());
-    assert_eq!(PathBuf::from(env::var("CRATE_MANIFEST_PATH").unwrap()), Path::new("Cargo.toml").canonicalize().unwrap());
+    assert_eq!(PathBuf::from(env::var("CRATE_MANIFEST_DIR").unwrap()), current_dir);
+    assert_eq!(PathBuf::from(env::var("CRATE_MANIFEST_PATH").unwrap()), current_dir.join("Cargo.toml"));
     assert_eq!(env::var("CRATE_PROFILE").unwrap(), "debug");
     assert_eq!(env::var("CRATE_TARGET").unwrap(), "");
     assert_eq!(env::var("CRATE_TARGET_TRIPLE").unwrap(), "");
-    assert_eq!(PathBuf::from(env::var("CRATE_TARGET_DIR").unwrap()), Path::new("../target").canonicalize().unwrap());
-    assert_eq!(PathBuf::from(env::var("CRATE_OUT_DIR").unwrap()), Path::new("../target").join("debug").canonicalize().unwrap());
+    assert_eq!(PathBuf::from(env::var("CRATE_TARGET_DIR").unwrap()), current_parent.join("target"));
+    assert_eq!(PathBuf::from(env::var("CRATE_OUT_DIR").unwrap()), current_parent.join("target/debug"));
     println!("ok");
 }

--- a/tests/simple/post_build.rs
+++ b/tests/simple/post_build.rs
@@ -10,6 +10,6 @@ fn main() {
     assert_eq!(env::var("CRATE_TARGET").unwrap(), "");
     assert_eq!(env::var("CRATE_TARGET_TRIPLE").unwrap(), "");
     assert_eq!(PathBuf::from(env::var("CRATE_TARGET_DIR").unwrap()), current_parent.join("target"));
-    assert_eq!(PathBuf::from(env::var("CRATE_OUT_DIR").unwrap()), current_parent.join("target/debug"));
+    assert_eq!(PathBuf::from(env::var("CRATE_OUT_DIR").unwrap()), current_parent.join("target").join("debug"));
     println!("ok");
 }


### PR DESCRIPTION
This should address #14. Using toml to escape the path string will be more robust than trying to do a replace.