### PR TITLE
Cargo run and multi-package workspaces

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,11 @@ jobs:
       - run: cargo post build --package simple
         working-directory: "tests/simple"
       - run: cargo post build --package dependency
-        working-directory: "tests/dependency"
+        working-directory: "tests/dependency" 
+      - run: cargo post build
+        working-directory: "tests" 
+      - run: cargo post run --package simple_run
+        working-directory: "tests"
 
   fmt:
     name: Rustfmt

--- a/Readme.md
+++ b/Readme.md
@@ -20,8 +20,6 @@ cargo post CMD [ARGS]
 
 The `post_build.rs` is only run if `CMD` is a build command like `build` or [`xbuild`](http://github.com/rust-osdev/cargo-xbuild/).
 
-In workspaces, you might have to pass a `--package` argument to `cargo build` to specify the package for which the post build script should be run.
-
 ### Examples:
 
 Build the crate and run `post_build.rs` afterwards:
@@ -52,6 +50,9 @@ The build script is not executed because `cargo check` is not a build command. T
 
 ## Post-Build Script Format
 
+### Inputs to the Post-Build Script
+
+When the build script is run, there are a number of inputs to the build script, all passed in the form of environment variables.
 Post-build scripts are similar to cargo build scripts, but they get a different set of environment variables:
 
 - `CRATE_BUILD_COMMAND`: The full cargo command that was used for building without `post`
@@ -64,6 +65,18 @@ Post-build scripts are similar to cargo build scripts, but they get a different 
     - Example: With `cargo post xbuild --target /some/path/to/your/target-x86_64.json` this environment variable has the value `target-x86_64`.
 - `CRATE_TARGET_DIR`: The path to the `target` directory of your crate.
 - `CRATE_OUT_DIR`: The path to the directory where cargo puts the compiled binaries. This path is constructed by appending `CRATE_TARGET_TRIPLE` and `CRATE_PROFILE` to `CRATE_TARGET_DIR`.
+- `CRATE_OUT_BINS`: The patch to the binaries currently being built, relative to `CRATE_OUT_DIR` and seperated by ':'. Example: `some_binary:examples/first_example:examples/second_example`.
+
+
+### Outputs of the Post-Build Script
+
+Post-build scripts may save any output files in the directory specified in the OUT_DIR environment variable. Scripts should not modify any files outside of that directory.
+
+Post-build scripts communicate with Cargo by printing to stdout in a similar way as build scripts. Cargo will interpret each line that starts with cargo: as an instruction that will influence how the package is run. All other lines are ignored.
+
+The following is a summary of the instructions that Cargo recognizes, with each one detailed below.
+
+- `cargo:updated-bin=oldBinPath=newBinPath` — Tells Cargo to use `newBinPath` rather than `oldBinPath` when running.
 
 ## Dependencies
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -137,6 +137,7 @@ fn main() {
 
             if let Some(ref output) = output {
                 if !output.status.success() {
+                    eprintln!("{}", String::from_utf8_lossy(&output.stderr));
                     process::exit(output.status.code().unwrap_or(1));
                 }
             }
@@ -154,7 +155,7 @@ fn main() {
             let mut bin = bins.next().expect("Found no binary to be executed!");
 
             if bins.next().is_some() {
-                panic!("More than one binary found! Use the `--bin` option to specify a binary, or the `default-run` manifest key")
+                panic!("More than one binary found! Use the `--bin` option to specify a binary")
             }
 
             // Parse stdout for `cargo:`
@@ -197,7 +198,7 @@ fn main() {
                     _ => {}
                 };
             }
-        };
+        }
     }
 }
 

--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -8,3 +8,6 @@ version = "0.1.0"
 name = "simple"
 version = "0.1.0"
 
+[[package]]
+name = "simple_run"
+version = "0.1.0"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
     "simple",
+    "simple_run",
     "dependency",
 ]

--- a/tests/dependency/post_build.rs
+++ b/tests/dependency/post_build.rs
@@ -1,17 +1,44 @@
-use std::{path::{Path, PathBuf}, env};
+use std::{env, path::PathBuf};
 
 use example as _;
 
 fn main() {
     let current_dir = env::current_dir().unwrap();
-    let current_parent = current_dir.parent().unwrap();
-    assert_eq!(env::var("CRATE_BUILD_COMMAND").unwrap(), "cargo build --package dependency");
-    assert_eq!(PathBuf::from(env::var("CRATE_MANIFEST_DIR").unwrap()), current_dir);
-    assert_eq!(PathBuf::from(env::var("CRATE_MANIFEST_PATH").unwrap()), current_dir.join("Cargo.toml"));
+
+    let package_dir = if env::var("CRATE_BUILD_COMMAND")
+        .unwrap()
+        .contains("--package")
+    {
+        assert_eq!(
+            env::var("CRATE_BUILD_COMMAND").unwrap(),
+            "cargo build --package dependency"
+        );
+        current_dir
+    } else {
+        assert_eq!(env::var("CRATE_BUILD_COMMAND").unwrap(), "cargo build");
+        current_dir.join("dependency")
+    };
+
+    let package_dir_parent = package_dir.parent().unwrap();
+
+    assert_eq!(
+        PathBuf::from(env::var("CRATE_MANIFEST_DIR").unwrap()),
+        package_dir
+    );
+    assert_eq!(
+        PathBuf::from(env::var("CRATE_MANIFEST_PATH").unwrap()),
+        package_dir.join("Cargo.toml")
+    );
+    assert_eq!(
+        PathBuf::from(env::var("CRATE_TARGET_DIR").unwrap()),
+        package_dir_parent.join("target")
+    );
+    assert_eq!(
+        PathBuf::from(env::var("CRATE_OUT_DIR").unwrap()),
+        package_dir_parent.join("target").join("debug")
+    );
     assert_eq!(env::var("CRATE_PROFILE").unwrap(), "debug");
     assert_eq!(env::var("CRATE_TARGET").unwrap(), "");
     assert_eq!(env::var("CRATE_TARGET_TRIPLE").unwrap(), "");
-    assert_eq!(PathBuf::from(env::var("CRATE_TARGET_DIR").unwrap()), current_parent.join("target"));
-    assert_eq!(PathBuf::from(env::var("CRATE_OUT_DIR").unwrap()), current_parent.join("target").join("debug"));
     println!("ok");
 }

--- a/tests/simple/post_build.rs
+++ b/tests/simple/post_build.rs
@@ -1,15 +1,42 @@
-use std::{path::PathBuf, env};
+use std::{env, path::PathBuf};
 
 fn main() {
     let current_dir = env::current_dir().unwrap();
-    let current_parent = current_dir.parent().unwrap();
-    assert_eq!(env::var("CRATE_BUILD_COMMAND").unwrap(), "cargo build --package simple");
-    assert_eq!(PathBuf::from(env::var("CRATE_MANIFEST_DIR").unwrap()), current_dir);
-    assert_eq!(PathBuf::from(env::var("CRATE_MANIFEST_PATH").unwrap()), current_dir.join("Cargo.toml"));
+
+    let package_dir = if env::var("CRATE_BUILD_COMMAND")
+        .unwrap()
+        .contains("--package")
+    {
+        assert_eq!(
+            env::var("CRATE_BUILD_COMMAND").unwrap(),
+            "cargo build --package simple"
+        );
+        current_dir
+    } else {
+        assert_eq!(env::var("CRATE_BUILD_COMMAND").unwrap(), "cargo build");
+        current_dir.join("simple")
+    };
+
+    let package_dir_parent = package_dir.parent().unwrap();
+
+    assert_eq!(
+        PathBuf::from(env::var("CRATE_MANIFEST_DIR").unwrap()),
+        package_dir
+    );
+    assert_eq!(
+        PathBuf::from(env::var("CRATE_MANIFEST_PATH").unwrap()),
+        package_dir.join("Cargo.toml")
+    );
+    assert_eq!(
+        PathBuf::from(env::var("CRATE_TARGET_DIR").unwrap()),
+        package_dir_parent.join("target")
+    );
+    assert_eq!(
+        PathBuf::from(env::var("CRATE_OUT_DIR").unwrap()),
+        package_dir_parent.join("target").join("debug")
+    );
     assert_eq!(env::var("CRATE_PROFILE").unwrap(), "debug");
     assert_eq!(env::var("CRATE_TARGET").unwrap(), "");
     assert_eq!(env::var("CRATE_TARGET_TRIPLE").unwrap(), "");
-    assert_eq!(PathBuf::from(env::var("CRATE_TARGET_DIR").unwrap()), current_parent.join("target"));
-    assert_eq!(PathBuf::from(env::var("CRATE_OUT_DIR").unwrap()), current_parent.join("target").join("debug"));
     println!("ok");
 }

--- a/tests/simple_run/Cargo.toml
+++ b/tests/simple_run/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "simple_run"
+version = "0.1.0"
+authors = ["Philipp Oppermann <dev@phil-opp.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/tests/simple_run/post_build.rs
+++ b/tests/simple_run/post_build.rs
@@ -1,0 +1,8 @@
+use std::{env, path::PathBuf};
+
+fn main() {
+    let current_dir = env::current_dir().unwrap();
+
+   
+    println!("ok");
+}

--- a/tests/simple_run/src/main.rs
+++ b/tests/simple_run/src/main.rs
@@ -1,0 +1,4 @@
+fn main() {
+    println!("Asserting that 2 + 2 = 4");
+    assert_eq!(2 + 2, 4);
+}


### PR DESCRIPTION
### Changes:
- Handle multiple packages in a workspace correctly, by building each package and running their respective post_build.rs, unless a package is specified
- Add `CRATE_OUT_BINS` environment variable, describing the binaries being built to the post-build script.
- Handle building multiple binaries in each package
- Handle building examples, both singular and plural
- Add support for 'Cargo run|test|install|publish|bench'. fixes #1 
- Introduce post-build outputs in a similar fashion as Cargo build scripts (https://doc.rust-lang.org/cargo/reference/build-scripts.html#outputs-of-the-build-script)
- Add `cargo:updated-bin` as a post-build output, to change the path of the binary being executed by 'Cargo run|test|install|publish|bench' from the post-build script
- Correct individual post-build examples to pass, and add a new example building the full test workspace
- Add simple `cargo post run` example to CI


### TODO:
- Handle custom runners from `.cargo/config`, as part of #2 
- Add support for the `default-run` manifest key