### PR TITLE
Make the init log make use of stderr

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -124,7 +124,7 @@ fn run_post_build_script() -> Option<process::ExitStatus> {
     if !post_build_script_path.exists() {
         return None;
     }
-    println!(
+    eprintln!(
         "Running Post Build Script at {}",
         post_build_script_path.display()
     );


### PR DESCRIPTION
In case that there are tasks done by users of cargo-post that makes use of stdout, I think it's best that we don't write anything into stdout when cargo-post starts successfully.