### PR TITLE
feat: Add option to use host target for post-build script

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "cargo-post"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "cargo_metadata",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-post"
-version = "0.1.7"
+version = "0.1.8"
 authors = ["Philipp Oppermann <dev@phil-opp.com>"]
 edition = "2018"
 readme = "Readme.md"


### PR DESCRIPTION
- Introduced `--use-host-triple` argument to allow the post-build script to be built using the system's host triple, overriding the main crate's target.
- Updated `cargo run` command to explicitly specify the target, ensuring any defaults in `.cargo/config` are overridden.

When building a Rust project for a different target (e.g., wasi), the main crate's dependencies and compilation process are tailored for that target. However, certain post-build scripts are system utilities and tools that need to run natively on the host system (e.g., macOS). By allowing the post-build script to use the host's target triple, we ensure that the script is compiled and executed correctly on the build system, even if the main crate is targeting a different platform. This provides flexibility in build processes, especially when cross-compiling.

Additionally adds new ENV variables & fixes #2 