### PR TITLE
Canonicalize dependency paths relative to manifest_dir

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -156,7 +156,9 @@ fn run_post_build_script() -> Option<process::ExitStatus> {
             .iter_mut()
         {
             if let Some(path) = dependency.get_mut("path") {
-                let dep_path = Path::new(path.as_str().expect("dependency path not a string"));
+                let dep_path = manifest_dir.join(Path::new(
+                    path.as_str().expect("dependency path not a string"),
+                ));
                 let path_canoncicalized = dep_path.canonicalize().unwrap_or_else(|_| {
                     panic!(
                         "Dependency {} does not exist at {}",


### PR DESCRIPTION
As per https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#specifying-path-dependencies a dependency's path should be given relative to the manifest's path.

The canonicalization of dependency paths in cargo-post implicitly uses the working directory to build the canonical path, this PR fixes that.